### PR TITLE
callback OnRspQryOrder with null order when requested

### DIFF
--- a/apis/CTP/Trade/TraderApi.cpp
+++ b/apis/CTP/Trade/TraderApi.cpp
@@ -1542,7 +1542,14 @@ int CTraderApi::_ReqQryOrder(char type, void* pApi1, void* pApi2, double double1
 void CTraderApi::OnOrder(CThostFtdcOrderField *pOrder, int nRequestID, bool bIsLast)
 {
 	if (nullptr == pOrder)
+	{
+		// 如果是请求报单而当日无报单，也需要回调告知 bIsLast = true
+		if (nRequestID != 0)
+		{
+			m_msgQueue->Input_Copy(ResponeType::ResponeType_OnRspQryOrder, m_msgQueue, m_pClass, bIsLast, 0, nullptr, sizeof(OrderField), nullptr, 0, nullptr, 0);
+		}
 		return;
+	}
 
 	OrderIDType orderId = { 0 };
 	sprintf(orderId, "%d:%d:%s", pOrder->FrontID, pOrder->SessionID, pOrder->OrderRef);


### PR DESCRIPTION
在请求当日报单后等待回报，如果当日没有报单，CTP仍然会回调 `OnRspQryOrder` 但返回的`OrderField`是空的，但现有实现直接不回调，导致请求后无法通过`bIsLast`确定这个操作已经完成。这个修改使得如果是请求当日报单，即使没有报单也会进行回调，提供一个空的报单以及`bIsLast`来告知回调结束，和CTP原有的行为一致。