### PR TITLE
ignore opendb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ ipch/
 *.opensdf
 *.sdf
 *.cachefile
+*.opendb
 
 # Visual Studio profiler
 *.psess


### PR DESCRIPTION
用 VS 编辑项目时会产生 opendb 文件，可让 git 忽略。